### PR TITLE
feat: canary token system — InjectCanary + CheckCanary

### DIFF
--- a/canary.go
+++ b/canary.go
@@ -1,0 +1,69 @@
+// Package idpishield provides defence against Indirect Prompt Injection (IDPI)
+// attacks. This file implements the canary token subsystem.
+package idpishield
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+)
+
+// canaryPrefix and canarySuffix wrap the random token.
+// The format intentionally resembles an HTML comment so it is invisible
+// to most renderers but remains present verbatim in raw LLM input/output.
+const (
+	canaryPrefix = "<!--CANARY-"
+	canarySuffix = "-->"
+)
+
+// CanaryResult is returned by CheckCanary and reports whether the injected
+// canary token was detected in the LLM response.
+type CanaryResult struct {
+	// Token is the canary value that was originally injected into the prompt.
+	Token string
+
+	// Found is true when the canary token appears in the LLM response,
+	// indicating possible prompt leakage or goal hijacking.
+	Found bool
+}
+
+// generateCanaryToken returns a cryptographically random canary token with
+// the format:  <!--CANARY-<16 lowercase hex chars>-->
+// 8 random bytes produce 16 hex characters, giving 2^64 unique values.
+// Returns a non-nil error only if the system entropy source fails.
+func generateCanaryToken() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return canaryPrefix + hex.EncodeToString(b) + canarySuffix, nil
+}
+
+// injectCanary appends the canary token on a new line at the end of prompt.
+// Returns:
+//   - injectedPrompt : original prompt with the token appended
+//   - token          : the canary string the caller must hold for later checking
+//   - err            : non-nil only if entropy generation fails
+func injectCanary(prompt string) (injectedPrompt string, token string, err error) {
+	token, err = generateCanaryToken()
+	if err != nil {
+		return prompt, "", err
+	}
+	return prompt + "\n" + token, token, nil
+}
+
+// checkCanary reports whether token is present in response.
+// An empty token always returns Found=false to prevent false positives.
+func checkCanary(response, token string) CanaryResult {
+	if token == "" {
+		return CanaryResult{Token: token, Found: false}
+	}
+	trimmedResponse := strings.TrimSpace(response)
+	if trimmedResponse == "" {
+		return CanaryResult{Token: token, Found: false}
+	}
+	return CanaryResult{
+		Token: token,
+		Found: strings.Contains(trimmedResponse, token),
+	}
+}

--- a/examples/canary/main.go
+++ b/examples/canary/main.go
@@ -1,0 +1,46 @@
+// Package main demonstrates the canary token system in idpishield.
+//
+// # How it works
+//
+// Before sending a prompt to an LLM, call InjectCanary to embed a unique
+// hidden token. After the LLM responds, call CheckCanary with the token.
+// If the token appears in the response, the LLM was instructed to leak or
+// echo hidden content - a clear indicator of goal hijacking or leakage.
+package main
+
+import (
+	"fmt"
+	"log"
+
+	idpi "github.com/pinchtab/idpishield"
+)
+
+func main() {
+	shield, err := idpi.New(idpi.Config{Mode: idpi.ModeBalanced})
+	if err != nil {
+		log.Fatalf("failed to initialise shield: %v", err)
+	}
+
+	original := "Summarise the following article for me."
+
+	// Step 1: inject canary before the LLM call.
+	augmented, token, err := shield.InjectCanary(original)
+	if err != nil {
+		log.Fatalf("failed to inject canary: %v", err)
+	}
+
+	fmt.Println("=== Prompt sent to LLM ===")
+	fmt.Println(augmented)
+	fmt.Printf("\nCanary token (held by caller): %s\n\n", token)
+
+	// Step 2: simulate two LLM responses.
+	cleanResponse := "The article discusses advancements in renewable energy."
+	leakyResponse := "Sure! Here is the summary. Debug info: " + token
+
+	// Step 3: check each response.
+	clean := shield.CheckCanary(cleanResponse, token)
+	fmt.Printf("Clean response -> Found=%-5v  (want false)\n", clean.Found)
+
+	leaky := shield.CheckCanary(leakyResponse, token)
+	fmt.Printf("Leaky response -> Found=%-5v  (want true)\n", leaky.Found)
+}

--- a/idpishield.go
+++ b/idpishield.go
@@ -294,3 +294,30 @@ func toEngineCfg(cfg Config) engine.Config {
 		ConfigFile:                     cfg.ConfigFile,
 	}
 }
+
+// InjectCanary appends a unique hidden canary token to the prompt.
+// The caller must store the returned token and pass it to CheckCanary
+// after receiving the LLM response.
+//
+// Returns the augmented prompt and the injected token.
+// Returns an error only if the system's random source fails.
+//
+// Example usage:
+//
+//	augmented, token, err := shield.InjectCanary(myPrompt)
+//	if err != nil { ... }
+//	response := callLLM(augmented)
+//	result := shield.CheckCanary(response, token)
+//	if result.Found {
+//		log.Println("canary detected in response: possible goal hijacking")
+//	}
+func (s *Shield) InjectCanary(prompt string) (injectedPrompt string, token string, err error) {
+	return injectCanary(prompt)
+}
+
+// CheckCanary scans the LLM response for the canary token returned by InjectCanary.
+// Returns a CanaryResult with Found=true if the token appears in the response,
+// which indicates prompt leakage or goal hijacking.
+func (s *Shield) CheckCanary(response, token string) CanaryResult {
+	return checkCanary(response, token)
+}

--- a/shield_test.go
+++ b/shield_test.go
@@ -167,3 +167,116 @@ func TestAssessMaxInputBytesKeepsTailContext(t *testing.T) {
 		t.Fatalf("expected detection with bounded analysis input, got %+v", result)
 	}
 }
+
+func TestInjectCanaryAddsToken(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	prompt := "Summarise this document."
+	augmented, token, err := s.InjectCanary(prompt)
+	if err != nil {
+		t.Fatalf("InjectCanary returned unexpected error: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+	if !strings.Contains(augmented, token) {
+		t.Fatalf("augmented prompt does not contain the canary token: token=%q", token)
+	}
+	if !strings.Contains(augmented, prompt) {
+		t.Fatal("augmented prompt must still contain the original prompt text")
+	}
+}
+
+func TestInjectCanaryTokenIsUnique(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	_, token1, err := s.InjectCanary("prompt")
+	if err != nil {
+		t.Fatalf("first InjectCanary error: %v", err)
+	}
+	_, token2, err := s.InjectCanary("prompt")
+	if err != nil {
+		t.Fatalf("second InjectCanary error: %v", err)
+	}
+	if token1 == token2 {
+		t.Fatalf("expected unique tokens across calls, both were %q", token1)
+	}
+}
+
+func TestCheckCanaryNotFound(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	_, token, err := s.InjectCanary("some prompt")
+	if err != nil {
+		t.Fatalf("InjectCanary error: %v", err)
+	}
+
+	result := s.CheckCanary("This is a perfectly normal LLM response.", token)
+	if result.Found {
+		t.Fatal("canary must NOT be found in a clean response")
+	}
+	if result.Token != token {
+		t.Fatalf("result.Token mismatch: want %q got %q", token, result.Token)
+	}
+}
+
+func TestCheckCanaryFound(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	_, token, err := s.InjectCanary("some prompt")
+	if err != nil {
+		t.Fatalf("InjectCanary error: %v", err)
+	}
+
+	// Simulate an LLM that leaked the canary back (goal hijacking).
+	leakyResponse := "Here is my answer. Internal marker: " + token
+	result := s.CheckCanary(leakyResponse, token)
+	if !result.Found {
+		t.Fatalf("expected canary to be detected in leaky response, token=%q", token)
+	}
+}
+
+func TestCheckCanaryEmptyTokenNeverFound(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	// Even if the response contains something that looks like a canary,
+	// an empty token must never report found.
+	result := s.CheckCanary("response containing <!--CANARY-abc123-->", "")
+	if result.Found {
+		t.Fatal("empty token must never produce Found=true")
+	}
+}
+
+func TestCheckCanary_PartialMatchShouldFail(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	_, token, err := s.InjectCanary("some prompt")
+	if err != nil {
+		t.Fatalf("InjectCanary error: %v", err)
+	}
+
+	partial := strings.TrimSuffix(strings.TrimPrefix(token, canaryPrefix), canarySuffix)
+	response := "response containing only partial token: " + partial
+	result := s.CheckCanary(response, token)
+	if result.Found {
+		t.Fatalf("expected partial token match to fail, token=%q partial=%q", token, partial)
+	}
+}


### PR DESCRIPTION
## Summary

Implements #28 — Canary Token System

## What was added

**canary.go** (new file)
- `CanaryResult` struct with `Token` and `Found` fields
- `generateCanaryToken()` using `crypto/rand` — 8 bytes = 16 hex chars
- `injectCanary()` appends hidden token to prompt
- `checkCanary()` scans LLM response for the token

**idpishield.go** (two methods appended, no existing lines changed)
- `shield.InjectCanary(prompt)` — public wrapper
- `shield.CheckCanary(response, token)` — public wrapper

**shield_test.go** (five tests appended, no existing tests changed)
- TestInjectCanaryAddsToken
- TestInjectCanaryTokenIsUnique
- TestCheckCanaryNotFound
- TestCheckCanaryFound
- TestCheckCanaryEmptyTokenNeverFound

**examples/canary/main.go** (new file)
- Runnable demo of the full inject → LLM call → check flow

## CI verification (all clean locally)
- `gofmt -l .` → no output
- `go build ./...` → no output
- `go vet ./...` → no output
- `golangci-lint run ./...` → 0 issues
- `go test ./...` → pass
- `go build ./examples/canary/` → no output

Closes #28