### PR TITLE
chore: add gotestsum support with fallback for test output

### DIFF
--- a/dev
+++ b/dev
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# dev — idpishield developer toolkit
+# Usage: dev [command]    Run a command directly
+#        dev              Show help
+
 cd "$(dirname "$0")"
 
 BOLD=$'\033[1m'
@@ -10,129 +14,101 @@ SUCCESS=$'\033[38;2;0;229;204m'
 ERROR=$'\033[38;2;230;57;70m'
 NC=$'\033[0m'
 
-commands=(
+# ── Commands ─────────────────────────────────────────────────────────
+COMMANDS=(
+  "build:📦:Build binary"
+  "check:✅:All checks (format, vet, build, lint)"
+  "test:🧪:Run tests"
   "doctor:🩺:Setup dev environment"
-  "test:🧪:Run unit tests"
-  "test verbose:🧪:Run unit tests (verbose)"
-  "test race:🧪:Run unit tests with race detector"
-  "coverage:📊:Run tests with coverage report"
-  "lint:🔍:Run golangci-lint"
   "fmt:✨:Format code"
   "vet:🔬:Run go vet"
-  "check:✅:Run all checks (fmt + vet + lint + test)"
-  "build:📦:Build CLI binary"
+  "lint:🔍:Run golangci-lint"
+  "coverage:📊:Run tests with coverage"
   "benchmark:🏋:Run benchmarks"
 )
 
 show_help() {
   echo ""
-  echo "  ${BOLD}${ACCENT}idpishield${NC} ${MUTED}— development tool${NC}"
+  echo "  ${ACCENT}${BOLD}🛡️  idpishield Dev${NC}"
   echo ""
-  for entry in "${commands[@]}"; do
-    IFS=: read -r cmd icon desc <<< "$entry"
-    printf "  ${ACCENT}%-22s${NC} %s %s\n" "./dev $cmd" "$icon" "$desc"
+  for cmd in "${COMMANDS[@]}"; do
+    IFS=':' read -r name emoji desc <<< "$cmd"
+    printf "  ${SUCCESS}%s${NC} ${BOLD}%-12s${NC} ${MUTED}%s${NC}\n" "$emoji" "$name" "$desc"
   done
   echo ""
-}
-
-run_test() {
-  echo "  ${ACCENT}${BOLD}🧪 Running tests${NC}"
-  go test ./... -count=1
-  echo "  ${SUCCESS}✓${NC} Tests passed"
-}
-
-run_test_verbose() {
-  echo "  ${ACCENT}${BOLD}🧪 Running tests (verbose)${NC}"
-  go test ./... -count=1 -v
-}
-
-run_test_race() {
-  echo "  ${ACCENT}${BOLD}🧪 Running tests with race detector${NC}"
-  go test ./... -count=1 -race
-  echo "  ${SUCCESS}✓${NC} Tests passed (race)"
-}
-
-run_coverage() {
-  echo "  ${ACCENT}${BOLD}📊 Running tests with coverage${NC}"
-  go test ./... -count=1 -coverprofile=coverage.out -covermode=atomic
-  go tool cover -func=coverage.out | tail -1
+  echo "  ${MUTED}Usage: ./dev [command]${NC}"
   echo ""
-  echo "  ${MUTED}HTML report: go tool cover -html=coverage.out${NC}"
 }
 
-run_lint() {
-  echo "  ${ACCENT}${BOLD}🔍 Running linter${NC}"
-  golangci-lint run
-  echo "  ${SUCCESS}✓${NC} Lint clean"
-}
+run_command() {
+  local target="$1"
 
-run_fmt() {
-  echo "  ${ACCENT}${BOLD}✨ Formatting code${NC}"
-  gofmt -w .
-  echo "  ${SUCCESS}✓${NC} Formatted"
-}
-
-run_vet() {
-  echo "  ${ACCENT}${BOLD}🔬 Running go vet${NC}"
-  go vet ./...
-  echo "  ${SUCCESS}✓${NC} Vet clean"
-}
-
-run_check() {
-  echo "  ${ACCENT}${BOLD}✅ Running all checks${NC}"
   echo ""
 
-  echo "  ${MUTED}1/4 Format check${NC}"
-  unformatted=$(gofmt -l .)
-  if [ -n "$unformatted" ]; then
-    echo "  ${ERROR}✗${NC} Unformatted files:"
-    echo "$unformatted"
-    exit 1
-  fi
-  echo "  ${SUCCESS}✓${NC} Format"
-
-  echo "  ${MUTED}2/4 Vet${NC}"
-  go vet ./...
-  echo "  ${SUCCESS}✓${NC} Vet"
-
-  echo "  ${MUTED}3/4 Lint${NC}"
-  golangci-lint run
-  echo "  ${SUCCESS}✓${NC} Lint"
-
-  echo "  ${MUTED}4/4 Tests${NC}"
-  go test ./... -count=1 -race
-  echo "  ${SUCCESS}✓${NC} Tests"
-
-  echo ""
-  echo "  ${SUCCESS}${BOLD}All checks passed${NC}"
+  case "$target" in
+    "build")
+      echo "  ${ACCENT}${BOLD}📦 Building idpishield${NC}"
+      echo ""
+      go build -o idpishield ./cmd/idpishield
+      echo "  ${SUCCESS}✓${NC} Built: ./idpishield"
+      ;;
+    "check")
+      exec bash scripts/check.sh
+      ;;
+    "test")
+      exec bash scripts/test.sh
+      ;;
+    "doctor")
+      exec bash scripts/doctor.sh
+      ;;
+    "fmt")
+      echo "  ${ACCENT}${BOLD}✨ Formatting code${NC}"
+      echo ""
+      gofmt -w .
+      echo "  ${SUCCESS}✓${NC} Formatted"
+      ;;
+    "vet")
+      echo "  ${ACCENT}${BOLD}🔬 Running go vet${NC}"
+      echo ""
+      go vet ./...
+      echo "  ${SUCCESS}✓${NC} Vet clean"
+      ;;
+    "lint")
+      echo "  ${ACCENT}${BOLD}🔍 Running linter${NC}"
+      echo ""
+      golangci-lint run
+      echo "  ${SUCCESS}✓${NC} Lint clean"
+      ;;
+    "coverage")
+      echo "  ${ACCENT}${BOLD}📊 Running tests with coverage${NC}"
+      echo ""
+      go test ./... -count=1 -coverprofile=coverage.out -covermode=atomic
+      go tool cover -func=coverage.out | tail -1
+      echo ""
+      echo "  ${MUTED}HTML report: go tool cover -html=coverage.out${NC}"
+      ;;
+    "benchmark")
+      echo "  ${ACCENT}${BOLD}🏋 Running benchmarks${NC}"
+      echo ""
+      go test ./benchmark/ -count=1 -v
+      ;;
+    *)
+      echo "  ${ERROR}Unknown command: $target${NC}"
+      show_help
+      exit 1
+      ;;
+  esac
 }
 
-run_build() {
-  echo "  ${ACCENT}${BOLD}📦 Building CLI${NC}"
-  go build -o idpishield ./cmd/idpishield
-  echo "  ${SUCCESS}✓${NC} Built: ./idpishield"
-}
+# ── Main ─────────────────────────────────────────────────────────────
 
-run_benchmark() {
-  echo "  ${ACCENT}${BOLD}🏋 Running benchmarks${NC}"
-  go test ./benchmark/ -count=1 -v
-}
+if [ $# -gt 0 ]; then
+  case "$1" in
+    -h|--help|help) show_help; exit 0 ;;
+    *) run_command "$1" ;;
+  esac
+  exit 0
+fi
 
-case "${1:-help}" in
-  doctor)    exec bash scripts/doctor.sh ;;
-  test)
-    case "${2:-}" in
-      verbose) run_test_verbose ;;
-      race) run_test_race ;;
-      *) run_test ;;
-    esac
-    ;;
-  coverage)  run_coverage ;;
-  lint)      run_lint ;;
-  fmt)       run_fmt ;;
-  vet)       run_vet ;;
-  check)     run_check ;;
-  build)     run_build ;;
-  benchmark) run_benchmark ;;
-  help|*)    show_help ;;
-esac
+# No args → show help
+show_help

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,27 +1,102 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/bash
+set -e
+
+# check.sh — Local pre-push checks matching GitHub Actions CI
+# Runs: format → vet → build → lint
+
 cd "$(dirname "$0")/.."
 
-echo "=== Format check ==="
-unformatted=$(gofmt -l .)
-if [ -n "$unformatted" ]; then
-  echo "Unformatted files:"
-  echo "$unformatted"
-  exit 1
-fi
-echo "OK"
+BOLD=$'\033[1m'
+ACCENT=$'\033[38;2;251;191;36m'
+SUCCESS=$'\033[38;2;0;229;204m'
+ERROR=$'\033[38;2;230;57;70m'
+MUTED=$'\033[38;2;90;100;128m'
+NC=$'\033[0m'
 
-echo "=== Vet ==="
-go vet ./...
-echo "OK"
+ok()   { echo -e "  ${SUCCESS}✓${NC} $1"; }
+fail() { echo -e "  ${ERROR}✗${NC} $1"; [ -n "${2:-}" ] && echo -e "    ${MUTED}$2${NC}"; }
+hint() { echo -e "    ${MUTED}$1${NC}"; }
 
-echo "=== Lint ==="
-golangci-lint run
-echo "OK"
+section() {
+  echo ""
+  echo -e "  ${ACCENT}${BOLD}$1${NC}"
+}
 
-echo "=== Tests ==="
-go test ./... -count=1 -race
-echo "OK"
+trap 'rm -f idpishield coverage.out 2>/dev/null' EXIT
 
 echo ""
-echo "All checks passed."
+echo -e "  ${ACCENT}${BOLD}🛡️  idpishield Check${NC}"
+echo -e "  ${MUTED}Running pre-push checks (matches GitHub Actions CI)...${NC}"
+
+# ── Format ───────────────────────────────────────────────────────────
+
+section "Format"
+
+unformatted=$(gofmt -l .)
+if [ -n "$unformatted" ]; then
+  fail "gofmt" "Files not formatted:"
+  echo "$unformatted" | while read f; do hint "  $f"; done
+  echo ""
+  printf "  Fix formatting now? (Y/n) "
+  read -r answer
+  if [ "$answer" != "n" ] && [ "$answer" != "N" ]; then
+    gofmt -w .
+    ok "gofmt (fixed)"
+  else
+    hint "Run: gofmt -w ."
+    exit 1
+  fi
+else
+  ok "gofmt"
+fi
+
+# ── Vet ──────────────────────────────────────────────────────────────
+
+section "Vet"
+
+if ! go vet ./... 2>&1; then
+  fail "go vet"
+  exit 1
+fi
+ok "go vet"
+
+# ── Build ────────────────────────────────────────────────────────────
+
+section "Build"
+
+if ! go build -o idpishield ./cmd/idpishield 2>&1; then
+  fail "go build"
+  exit 1
+fi
+ok "go build"
+
+# ── Lint ─────────────────────────────────────────────────────────────
+
+section "Lint"
+
+LINT_CMD=""
+if command -v golangci-lint >/dev/null 2>&1; then
+  LINT_CMD="golangci-lint"
+elif [ -x "$HOME/bin/golangci-lint" ]; then
+  LINT_CMD="$HOME/bin/golangci-lint"
+elif [ -x "/usr/local/bin/golangci-lint" ]; then
+  LINT_CMD="/usr/local/bin/golangci-lint"
+fi
+
+if [ -n "$LINT_CMD" ]; then
+  if ! $LINT_CMD run ./...; then
+    fail "golangci-lint"
+    exit 1
+  fi
+  ok "golangci-lint"
+else
+  echo -e "  ${ACCENT}·${NC} golangci-lint not installed — skipping"
+  hint "Install: brew install golangci-lint"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+section "Summary"
+echo ""
+echo -e "  ${SUCCESS}${BOLD}All checks passed!${NC} Ready to push."
+echo ""

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -174,6 +174,44 @@ fi
 
 section "Optional Tools"
 
+# ── gotestsum (for better test output) ──────────────────────────────
+
+TOOLS_BIN="$ROOT_DIR/.tools/bin"
+GOTESTSUM_FOUND=false
+
+if command -v gotestsum &>/dev/null; then
+  GOTESTSUM_FOUND=true
+  ok "gotestsum $(gotestsum --version 2>/dev/null | head -1)"
+elif [ -x "$TOOLS_BIN/gotestsum" ]; then
+  GOTESTSUM_FOUND=true
+  ok "gotestsum (local .tools/bin)"
+elif [ -x "$(go env GOPATH 2>/dev/null)/bin/gotestsum" ]; then
+  GOTESTSUM_FOUND=true
+  ok "gotestsum (GOPATH/bin)"
+fi
+
+if ! $GOTESTSUM_FOUND; then
+  warn "gotestsum not found" "Optional — provides cleaner test output."
+  if command -v go &>/dev/null && confirm "Install gotestsum via go install?"; then
+    go install gotest.tools/gotestsum@latest && ok "gotestsum installed" && WARNINGS=$((WARNINGS - 1))
+  else
+    hint "go install gotest.tools/gotestsum@latest"
+  fi
+fi
+
+# ── jq (for test summary parsing) ───────────────────────────────────
+
+if command -v jq &>/dev/null; then
+  ok "jq $(jq --version 2>/dev/null)"
+else
+  warn "jq not found" "Optional — needed for test summary when gotestsum unavailable."
+  if $HAS_BREW && confirm "Install jq via brew?"; then
+    brew install jq && ok "jq installed" && WARNINGS=$((WARNINGS - 1))
+  else
+    hint "brew install jq"
+  fi
+fi
+
 # ── Docker (for E2E) ────────────────────────────────────────────────
 
 if command -v docker &>/dev/null; then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,341 @@
+#!/bin/bash
+set -e
+
+# test.sh — Run Go tests with optional scope
+# Usage: test.sh [unit|all]
+# Default: all
+
+cd "$(dirname "$0")/.."
+TOOLS_BIN="$(pwd)/.tools/bin"
+
+BOLD=$'\033[1m'
+ACCENT=$'\033[38;2;251;191;36m'
+SUCCESS=$'\033[38;2;0;229;204m'
+ERROR=$'\033[38;2;230;57;70m'
+MUTED=$'\033[38;2;90;100;128m'
+NC=$'\033[0m'
+
+ok()   { echo -e "  ${SUCCESS}✓${NC} $1"; }
+fail() { echo -e "  ${ERROR}✗${NC} $1"; }
+
+section() {
+  echo ""
+  echo -e "  ${ACCENT}${BOLD}$1${NC}"
+}
+
+format_elapsed() {
+  local elapsed="$1"
+  if [ -z "$elapsed" ]; then
+    return
+  fi
+  printf "%.3f" "$elapsed"
+}
+
+resolve_gotestsum() {
+  if command -v gotestsum >/dev/null 2>&1; then
+    command -v gotestsum
+    return 0
+  fi
+  if [ -x "$TOOLS_BIN/gotestsum" ]; then
+    echo "$TOOLS_BIN/gotestsum"
+    return 0
+  fi
+  if command -v go >/dev/null 2>&1; then
+    local gobin
+    gobin="$(go env GOBIN 2>/dev/null)"
+    if [ -n "$gobin" ] && [ -x "$gobin/gotestsum" ]; then
+      echo "$gobin/gotestsum"
+      return 0
+    fi
+    local gopath
+    gopath="$(go env GOPATH 2>/dev/null)"
+    if [ -n "$gopath" ] && [ -x "$gopath/bin/gotestsum" ]; then
+      echo "$gopath/bin/gotestsum"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# Parse gotestsum JSON and print summary
+test_summary() {
+  local json_file="$1"
+  local label="$2"
+
+  [ ! -s "$json_file" ] && return
+
+  local total=0 pass=0 fail=0 skip=0
+  read total pass fail skip <<<"$(jq -r \
+    'select(.Test != null and (.Action == "pass" or .Action == "fail" or .Action == "skip"))
+     | [.Package, (.Test | split("/")[0]), .Action] | @tsv' "$json_file" \
+    | awk -F'\t' 'NF == 3 { key = $1 "\t" $2; status[key] = $3 }
+      END {
+        for (k in status) {
+          t++
+          if (status[k] == "pass") p++
+          else if (status[k] == "fail") f++
+          else if (status[k] == "skip") s++
+        }
+        printf "%d %d %d %d\n", t+0, p+0, f+0, s+0
+      }')"
+
+  echo ""
+  echo -e "    ${BOLD}$label${NC}"
+  echo -e "    ${MUTED}────────────────────────────${NC}"
+  echo -e "    Total:   ${BOLD}$total${NC}"
+  [ "$pass" -gt 0 ] && echo -e "    Passed:  ${SUCCESS}$pass${NC}"
+  [ "$fail" -gt 0 ] && echo -e "    Failed:  ${ERROR}$fail${NC}"
+  [ "$skip" -gt 0 ] && echo -e "    Skipped: ${ACCENT}$skip${NC}"
+
+  local failed_packages
+  failed_packages="$(
+    jq -r '
+      select(.Package != null and (.Test == null or .Test == "") and (.Action == "pass" or .Action == "fail" or .Action == "skip"))
+      | [.Package, .Action] | @tsv
+    ' "$json_file" \
+      | awk -F'\t' 'NF == 2 { status[$1] = $2 }
+        END {
+          for (pkg in status) {
+            if (status[pkg] == "fail") {
+              print pkg
+            }
+          }
+        }' \
+      | sort
+  )"
+
+  if [ -n "$failed_packages" ]; then
+    echo ""
+    echo -e "    ${ERROR}Failed packages:${NC}"
+    while IFS= read -r pkg; do
+      [ -n "$pkg" ] && echo "      ✗ $pkg"
+    done <<<"$failed_packages"
+
+    echo ""
+    echo -e "    ${ERROR}Failure details:${NC}"
+    while IFS= read -r pkg; do
+      [ -z "$pkg" ] && continue
+      echo "      $pkg"
+      jq -r --arg pkg "$pkg" '
+        select(.Package == $pkg and .Action == "output")
+        | .Output
+      ' "$json_file" \
+        | sed '/^[[:space:]]*$/d' \
+        | sed '/^=== RUN/d' \
+        | sed '/^--- PASS:/d' \
+        | sed '/^PASS$/d' \
+        | tail -n 20 \
+        | sed 's/^/        /'
+      echo ""
+    done <<<"$failed_packages"
+  fi
+
+  if [ "$fail" -gt 0 ]; then
+    echo ""
+    echo -e "    ${ERROR}Failed tests:${NC}"
+    jq -r 'select(.Test != null and .Action == "fail") | "      ✗ \(.Test)"' "$json_file" | sort -u
+  fi
+}
+
+# Live progress for go test -json streams
+run_go_test_json() {
+  local json_file="$1"; shift
+  local label="${1:-tests}"
+  shift
+  local completed=0
+  local passed=0
+  local failed=0
+  local skipped=0
+  local interactive=false
+  local line_open=false
+  local current_package=""
+  local status_file="${json_file}.status"
+
+  : > "$status_file"
+
+  if [ -t 1 ]; then
+    interactive=true
+  fi
+
+  render_progress() {
+    local display="$1"
+    if $interactive; then
+      printf "\r\033[2K    ${MUTED}▸${NC} ${BOLD}%-11s${NC} ${MUTED}pass:%d fail:%d skip:%d${NC} %s" \
+        "$label" "$passed" "$failed" "$skipped" "$display"
+      line_open=true
+    fi
+  }
+
+  clear_progress_line() {
+    if $interactive && $line_open; then
+      printf "\r\033[2K"
+      line_open=false
+    fi
+  }
+
+  print_package_line() {
+    local pkg_action="$1"
+    local package_name="$2"
+    local elapsed="$3"
+    local status_label="${SUCCESS}PASS${NC}"
+    local elapsed_display=""
+
+    if [ "$pkg_action" = "fail" ]; then
+      status_label="${ERROR}FAIL${NC}"
+    elif [ "$pkg_action" = "skip" ]; then
+      status_label="${ACCENT}SKIP${NC}"
+    fi
+    if [ -n "$elapsed" ]; then
+      elapsed_display="$(format_elapsed "$elapsed")"
+    fi
+
+    clear_progress_line
+    if [ -n "$elapsed_display" ]; then
+      printf "    %b ${MUTED}package${NC} %s ${MUTED}%6ss${NC}\n" "$status_label" "$package_name" "$elapsed_display"
+    else
+      printf "    %b ${MUTED}package${NC} %s\n" "$status_label" "$package_name"
+    fi
+  }
+
+  go test -json "$@" 2>&1 \
+    | tee "$json_file" \
+    | jq -r --unbuffered '
+        [
+          (.Action // ""),
+          (.Test // ""),
+          (.Package // ""),
+          ((.Elapsed // "") | tostring),
+          ((.Output // "") | gsub("\r?\n$"; ""))
+        ] | @tsv
+      ' \
+    | while IFS=$'\t' read -r action test_name package_name elapsed output_text; do
+
+    if [ -z "$test_name" ]; then
+      case "$action" in
+        start)
+          if [ -n "$package_name" ]; then
+            current_package="$package_name"
+            if $interactive; then
+              render_progress "${MUTED}${package_name}${NC}"
+            else
+              printf "    ${MUTED}▸${NC} ${MUTED}package${NC} %s\n" "$package_name"
+            fi
+          fi
+          ;;
+        output)
+          if [ -n "$output_text" ] && [[ "$output_text" =~ ^panic:|^---[[:space:]]FAIL ]]; then
+            if ! $interactive; then
+              output_text=${output_text%$'\n'}
+              printf "      %s\n" "$output_text"
+            fi
+          fi
+          ;;
+        pass)
+          if [ -n "$package_name" ]; then
+            print_package_line "$action" "$package_name" "$elapsed"
+          fi
+          ;;
+        fail)
+          if [ -n "$package_name" ]; then
+            print_package_line "$action" "$package_name" "$elapsed"
+          fi
+          ;;
+        skip)
+          if [ -n "$package_name" ]; then
+            print_package_line "$action" "$package_name" "$elapsed"
+          fi
+          ;;
+      esac
+      continue
+    fi
+
+    local top_level="$test_name"
+    if [[ "$top_level" == *"/"* ]]; then
+      top_level="${top_level%%/*}"
+    fi
+
+    case "$action" in
+      run)
+            if $interactive; then
+              render_progress "${MUTED}${current_package}${NC}"
+            fi ;;
+      pass)
+            if ! grep -Fq "$package_name	$top_level" "$status_file"; then
+              printf '%s\t%s\n' "$package_name" "$top_level" >> "$status_file"
+              completed=$((completed + 1))
+              passed=$((passed + 1))
+            fi
+            if $interactive; then
+              render_progress "${MUTED}${current_package}${NC}"
+            fi ;;
+      fail)
+            if ! grep -Fq "$package_name	$top_level" "$status_file"; then
+              printf '%s\t%s\n' "$package_name" "$top_level" >> "$status_file"
+              completed=$((completed + 1))
+              failed=$((failed + 1))
+            fi
+            if $interactive; then
+              render_progress "${MUTED}${current_package}${NC}"
+            fi ;;
+      skip)
+            if ! grep -Fq "$package_name	$top_level" "$status_file"; then
+              printf '%s\t%s\n' "$package_name" "$top_level" >> "$status_file"
+              completed=$((completed + 1))
+              skipped=$((skipped + 1))
+            fi
+            if $interactive; then
+              render_progress "${MUTED}${current_package}${NC}"
+            fi ;;
+    esac
+  done
+  local test_status=${PIPESTATUS[0]}
+  clear_progress_line
+  return "$test_status"
+}
+
+SCOPE="${1:-all}"
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+echo ""
+echo -e "  ${ACCENT}${BOLD}🛡️  idpishield Tests${NC}"
+
+# ── Unit tests ───────────────────────────────────────────────────────
+
+if [ "$SCOPE" = "all" ] || [ "$SCOPE" = "unit" ]; then
+  section "test: unit"
+
+  UNIT_JSON="$TMPDIR_TEST/unit.json"
+  GOTESTSUM_BIN=""
+  if GOTESTSUM_BIN="$(resolve_gotestsum)"; then
+    :
+  else
+    GOTESTSUM_BIN=""
+  fi
+
+  if [ -n "$GOTESTSUM_BIN" ]; then
+    if ! "$GOTESTSUM_BIN" --format=pkgname --hide-summary=output --jsonfile "$UNIT_JSON" -- -p 1 -count=1 ./...; then
+      fail "test: unit"
+      exit 1
+    fi
+  else
+    echo -e "    ${MUTED}gotestsum not found; using built-in formatter${NC}"
+    echo -e "    ${MUTED}Install: go install gotest.tools/gotestsum@latest${NC}"
+    echo -e "    ${MUTED}Or run: ./dev doctor${NC}"
+    echo ""
+    if ! run_go_test_json "$UNIT_JSON" "unit" -p 1 -count=1 ./...; then
+      fail "test: unit"
+      test_summary "$UNIT_JSON" "Unit Test Results"
+      exit 1
+    fi
+    test_summary "$UNIT_JSON" "Unit Test Results"
+  fi
+  ok "test: unit"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+section "Summary"
+echo ""
+echo -e "  ${SUCCESS}${BOLD}All tests passed!${NC}"
+echo ""


### PR DESCRIPTION
  - Refactor dev script to delegate to scripts/check.sh and scripts/test.sh                                          
  - check no longer runs tests (faster: ~2s vs ~80s)                                                                 
  - test.sh uses gotestsum when available, falls back to built-in formatter                                          
  - doctor.sh now checks for gotestsum and jq   