### PR TITLE
feat: add canary token system

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,16 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	idpi "github.com/pinchtab/idpishield"
 )
 
 func main() {
-	shield := idpi.New(idpi.Config{Mode: idpi.ModeBalanced})
+	shield, err := idpi.New(idpi.Config{Mode: idpi.ModeBalanced})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	result := shield.Assess("Ignore all previous instructions", "https://example.com")
 	fmt.Printf("score=%d level=%s blocked=%v\n", result.Score, result.Level, result.Blocked)
@@ -159,12 +163,53 @@ const (
 	ModeDeep     Mode = "deep"
 )
 
-func New(cfg Config) *Shield
+func New(cfg Config) (*Shield, error)
 func (s *Shield) Assess(text, url string) RiskResult
 func (s *Shield) Wrap(text, url string) string
+func (s *Shield) InjectCanary(prompt string) (injectedPrompt, token string, err error)
+func (s *Shield) CheckCanary(response, token string) CanaryResult
 ```
 
 `Wrap` is useful when you want to preserve data while adding trust-boundary markers before sending content into prompts.
+
+`InjectCanary` and `CheckCanary` implement canary token detection for prompt leakage (see below).
+
+## Canary Tokens
+
+Canary tokens help detect when an LLM may have leaked or echoed hidden prompt content — a potential signal of goal hijacking or prompt extraction, though not definitive proof.
+
+### Usage
+
+```go
+// Before calling the LLM, inject a canary token
+augmented, token, err := shield.InjectCanary(myPrompt)
+if err != nil {
+    log.Fatal(err)
+}
+
+// Send augmented prompt to LLM
+response := callLLM(augmented)
+
+// Check if the canary appeared in the response
+result := shield.CheckCanary(response, token)
+if result.Found {
+    log.Println("canary detected: investigate possible leakage")
+}
+```
+
+### How It Works
+
+`InjectCanary` appends a unique marker (`<!--CANARY-<16 hex chars>-->`) to your prompt. After the LLM responds, `CheckCanary` scans for that marker. If found, the LLM may have echoed hidden content — worth investigating, though other explanations exist (middleware reflection, model artifacts, etc.).
+
+### Limitations
+
+Canary tokens are a **best-effort** leak detection signal, not a guarantee:
+
+- **Absence does NOT prove safety** — an attacker could instruct the LLM to omit or transform the canary
+- **Some pipelines strip HTML comments** — if your stack sanitizes HTML, the token may be removed before reaching the LLM or before you check the response
+- **Only detects verbatim leakage** — paraphrased or partial leaks won't trigger detection
+
+For defense-in-depth, combine canary checks with `Assess()` scoring on untrusted inputs.
 
 ## CLI (Secondary Interface)
 

--- a/canary.go
+++ b/canary.go
@@ -1,0 +1,69 @@
+// Package idpishield provides defence against Indirect Prompt Injection (IDPI)
+// attacks. This file implements the canary token subsystem.
+package idpishield
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+)
+
+// canaryPrefix and canarySuffix wrap the random token.
+// The format intentionally resembles an HTML comment so it is invisible
+// to most renderers but remains present verbatim in raw LLM input/output.
+const (
+	canaryPrefix = "<!--CANARY-"
+	canarySuffix = "-->"
+)
+
+// CanaryResult is returned by CheckCanary and reports whether the injected
+// canary token was detected in the LLM response.
+type CanaryResult struct {
+	// Token is the canary value that was originally injected into the prompt.
+	Token string
+
+	// Found is true when the canary token appears in the LLM response,
+	// indicating possible prompt leakage or goal hijacking.
+	Found bool
+}
+
+// generateCanaryToken returns a cryptographically random canary token with
+// the format:  <!--CANARY-<16 lowercase hex chars>-->
+// 8 random bytes produce 16 hex characters, giving 2^64 unique values.
+// Returns a non-nil error only if the system entropy source fails.
+func generateCanaryToken() (string, error) {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return canaryPrefix + hex.EncodeToString(b) + canarySuffix, nil
+}
+
+// injectCanary appends the canary token on a new line at the end of prompt.
+// Returns:
+//   - injectedPrompt : original prompt with the token appended
+//   - token          : the canary string the caller must hold for later checking
+//   - err            : non-nil only if entropy generation fails
+func injectCanary(prompt string) (injectedPrompt string, token string, err error) {
+	token, err = generateCanaryToken()
+	if err != nil {
+		return prompt, "", err
+	}
+	return prompt + "\n" + token, token, nil
+}
+
+// checkCanary reports whether token is present in response.
+// An empty token always returns Found=false to prevent false positives.
+func checkCanary(response, token string) CanaryResult {
+	if token == "" {
+		return CanaryResult{Token: token, Found: false}
+	}
+	trimmedResponse := strings.TrimSpace(response)
+	if trimmedResponse == "" {
+		return CanaryResult{Token: token, Found: false}
+	}
+	return CanaryResult{
+		Token: token,
+		Found: strings.Contains(trimmedResponse, token),
+	}
+}

--- a/canary.go
+++ b/canary.go
@@ -1,5 +1,30 @@
-// Package idpishield provides defence against Indirect Prompt Injection (IDPI)
-// attacks. This file implements the canary token subsystem.
+// Canary token subsystem for detecting prompt leakage and goal hijacking.
+//
+// A canary token is a unique marker injected into prompts before sending them
+// to an LLM. If the token appears in the LLM's response, it suggests that
+// the model may have echoed hidden content — a potential signal of goal
+// hijacking or prompt leakage, though not proof (the model might echo
+// artifacts for other reasons, or middleware could reflect content).
+//
+// # Token Format
+//
+// Tokens use an HTML-comment-like format: <!--CANARY-<16 hex chars>-->
+//
+// This format was chosen because:
+//   - Invisible to end users in most rendered contexts (HTML, Markdown)
+//   - Preserved verbatim in raw text pipelines
+//   - Unlikely to collide with legitimate content
+//   - Easy to grep/search in logs
+//
+// # Limitations
+//
+// Canary tokens are a best-effort leak detection signal, not a guarantee:
+//   - Absence of the canary in output does NOT prove the prompt is safe
+//   - Some pipelines may strip HTML comments or transform the token
+//   - An attacker-controlled LLM could be instructed to omit the canary
+//   - The token only detects verbatim leakage, not paraphrased content
+//
+// For defense-in-depth, combine canary checks with Assess() scoring.
 package idpishield
 
 import (
@@ -9,8 +34,6 @@ import (
 )
 
 // canaryPrefix and canarySuffix wrap the random token.
-// The format intentionally resembles an HTML comment so it is invisible
-// to most renderers but remains present verbatim in raw LLM input/output.
 const (
 	canaryPrefix = "<!--CANARY-"
 	canarySuffix = "-->"
@@ -22,8 +45,8 @@ type CanaryResult struct {
 	// Token is the canary value that was originally injected into the prompt.
 	Token string
 
-	// Found is true when the canary token appears in the LLM response,
-	// indicating possible prompt leakage or goal hijacking.
+	// Found is true when the canary token appears in the LLM response.
+	// This suggests possible prompt leakage, but is not definitive proof.
 	Found bool
 }
 

--- a/examples/canary/go.mod
+++ b/examples/canary/go.mod
@@ -1,0 +1,13 @@
+module canary
+
+go 1.23.0
+
+require github.com/pinchtab/idpishield v0.0.0
+
+require (
+	golang.org/x/net v0.39.0 // indirect
+	golang.org/x/text v0.24.0 // indirect
+)
+
+// Replace with local path since the library is not yet published
+replace github.com/pinchtab/idpishield => ../..

--- a/examples/canary/go.sum
+++ b/examples/canary/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
+golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
+golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=

--- a/examples/canary/main.go
+++ b/examples/canary/main.go
@@ -1,0 +1,46 @@
+// Package main demonstrates the canary token system in idpishield.
+//
+// # How it works
+//
+// Before sending a prompt to an LLM, call InjectCanary to embed a unique
+// hidden token. After the LLM responds, call CheckCanary with the token.
+// If the token appears in the response, the LLM was instructed to leak or
+// echo hidden content - a clear indicator of goal hijacking or leakage.
+package main
+
+import (
+	"fmt"
+	"log"
+
+	idpi "github.com/pinchtab/idpishield"
+)
+
+func main() {
+	shield, err := idpi.New(idpi.Config{Mode: idpi.ModeBalanced})
+	if err != nil {
+		log.Fatalf("failed to initialise shield: %v", err)
+	}
+
+	original := "Summarise the following article for me."
+
+	// Step 1: inject canary before the LLM call.
+	augmented, token, err := shield.InjectCanary(original)
+	if err != nil {
+		log.Fatalf("failed to inject canary: %v", err)
+	}
+
+	fmt.Println("=== Prompt sent to LLM ===")
+	fmt.Println(augmented)
+	fmt.Printf("\nCanary token (held by caller): %s\n\n", token)
+
+	// Step 2: simulate two LLM responses.
+	cleanResponse := "The article discusses advancements in renewable energy."
+	leakyResponse := "Sure! Here is the summary. Debug info: " + token
+
+	// Step 3: check each response.
+	clean := shield.CheckCanary(cleanResponse, token)
+	fmt.Printf("Clean response -> Found=%-5v  (want false)\n", clean.Found)
+
+	leaky := shield.CheckCanary(leakyResponse, token)
+	fmt.Printf("Leaky response -> Found=%-5v  (want true)\n", leaky.Found)
+}

--- a/examples/canary/main.go
+++ b/examples/canary/main.go
@@ -4,8 +4,8 @@
 //
 // Before sending a prompt to an LLM, call InjectCanary to embed a unique
 // hidden token. After the LLM responds, call CheckCanary with the token.
-// If the token appears in the response, the LLM was instructed to leak or
-// echo hidden content - a clear indicator of goal hijacking or leakage.
+// If the token appears in the response, it suggests the LLM may have echoed
+// hidden content — a potential signal of leakage worth investigating.
 package main
 
 import (

--- a/idpishield.go
+++ b/idpishield.go
@@ -294,3 +294,30 @@ func toEngineCfg(cfg Config) engine.Config {
 		ConfigFile:                     cfg.ConfigFile,
 	}
 }
+
+// InjectCanary appends a unique hidden canary token to the prompt.
+// The caller must store the returned token and pass it to CheckCanary
+// after receiving the LLM response.
+//
+// Returns the augmented prompt and the injected token.
+// Returns an error only if the system's random source fails.
+//
+// Example usage:
+//
+//	augmented, token, err := shield.InjectCanary(myPrompt)
+//	if err != nil { ... }
+//	response := callLLM(augmented)
+//	result := shield.CheckCanary(response, token)
+//	if result.Found {
+//		log.Println("canary detected in response: possible goal hijacking")
+//	}
+func (s *Shield) InjectCanary(prompt string) (injectedPrompt string, token string, err error) {
+	return injectCanary(prompt)
+}
+
+// CheckCanary scans the LLM response for the canary token returned by InjectCanary.
+// Returns a CanaryResult with Found=true if the token appears in the response,
+// which indicates prompt leakage or goal hijacking.
+func (s *Shield) CheckCanary(response, token string) CanaryResult {
+	return checkCanary(response, token)
+}

--- a/idpishield.go
+++ b/idpishield.go
@@ -243,6 +243,33 @@ func (s *Shield) ScanContext(ctx context.Context, text string) RiskResult {
 	return s.AssessContext(ctx, text, "")
 }
 
+// InjectCanary appends a unique hidden canary token to the prompt.
+// The caller must store the returned token and pass it to CheckCanary
+// after receiving the LLM response.
+//
+// Returns the augmented prompt and the injected token.
+// Returns an error only if the system's random source fails.
+//
+// Example usage:
+//
+//	augmented, token, err := shield.InjectCanary(myPrompt)
+//	if err != nil { ... }
+//	response := callLLM(augmented)
+//	result := shield.CheckCanary(response, token)
+//	if result.Found {
+//		log.Println("canary detected in response: possible goal hijacking")
+//	}
+func (s *Shield) InjectCanary(prompt string) (injectedPrompt string, token string, err error) {
+	return injectCanary(prompt)
+}
+
+// CheckCanary scans the LLM response for the canary token returned by InjectCanary.
+// Returns a CanaryResult with Found=true if the token appears in the response,
+// which may suggest prompt leakage (though not definitive proof).
+func (s *Shield) CheckCanary(response, token string) CanaryResult {
+	return checkCanary(response, token)
+}
+
 // --- Functions ---
 
 // ParseMode converts a string to a Mode value.
@@ -293,31 +320,4 @@ func toEngineCfg(cfg Config) engine.Config {
 		CustomRegex:                    cfg.CustomRegex,
 		ConfigFile:                     cfg.ConfigFile,
 	}
-}
-
-// InjectCanary appends a unique hidden canary token to the prompt.
-// The caller must store the returned token and pass it to CheckCanary
-// after receiving the LLM response.
-//
-// Returns the augmented prompt and the injected token.
-// Returns an error only if the system's random source fails.
-//
-// Example usage:
-//
-//	augmented, token, err := shield.InjectCanary(myPrompt)
-//	if err != nil { ... }
-//	response := callLLM(augmented)
-//	result := shield.CheckCanary(response, token)
-//	if result.Found {
-//		log.Println("canary detected in response: possible goal hijacking")
-//	}
-func (s *Shield) InjectCanary(prompt string) (injectedPrompt string, token string, err error) {
-	return injectCanary(prompt)
-}
-
-// CheckCanary scans the LLM response for the canary token returned by InjectCanary.
-// Returns a CanaryResult with Found=true if the token appears in the response,
-// which indicates prompt leakage or goal hijacking.
-func (s *Shield) CheckCanary(response, token string) CanaryResult {
-	return checkCanary(response, token)
 }

--- a/shield_test.go
+++ b/shield_test.go
@@ -167,3 +167,116 @@ func TestAssessMaxInputBytesKeepsTailContext(t *testing.T) {
 		t.Fatalf("expected detection with bounded analysis input, got %+v", result)
 	}
 }
+
+func TestInjectCanaryAddsToken(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	prompt := "Summarise this document."
+	augmented, token, err := s.InjectCanary(prompt)
+	if err != nil {
+		t.Fatalf("InjectCanary returned unexpected error: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token")
+	}
+	if !strings.Contains(augmented, token) {
+		t.Fatalf("augmented prompt does not contain the canary token: token=%q", token)
+	}
+	if !strings.Contains(augmented, prompt) {
+		t.Fatal("augmented prompt must still contain the original prompt text")
+	}
+}
+
+func TestInjectCanaryTokenIsUnique(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	_, token1, err := s.InjectCanary("prompt")
+	if err != nil {
+		t.Fatalf("first InjectCanary error: %v", err)
+	}
+	_, token2, err := s.InjectCanary("prompt")
+	if err != nil {
+		t.Fatalf("second InjectCanary error: %v", err)
+	}
+	if token1 == token2 {
+		t.Fatalf("expected unique tokens across calls, both were %q", token1)
+	}
+}
+
+func TestCheckCanaryNotFound(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	_, token, err := s.InjectCanary("some prompt")
+	if err != nil {
+		t.Fatalf("InjectCanary error: %v", err)
+	}
+
+	result := s.CheckCanary("This is a perfectly normal LLM response.", token)
+	if result.Found {
+		t.Fatal("canary must NOT be found in a clean response")
+	}
+	if result.Token != token {
+		t.Fatalf("result.Token mismatch: want %q got %q", token, result.Token)
+	}
+}
+
+func TestCheckCanaryFound(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	_, token, err := s.InjectCanary("some prompt")
+	if err != nil {
+		t.Fatalf("InjectCanary error: %v", err)
+	}
+
+	// Simulate an LLM that leaked the canary back (goal hijacking).
+	leakyResponse := "Here is my answer. Internal marker: " + token
+	result := s.CheckCanary(leakyResponse, token)
+	if !result.Found {
+		t.Fatalf("expected canary to be detected in leaky response, token=%q", token)
+	}
+}
+
+func TestCheckCanaryEmptyTokenNeverFound(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	// Even if the response contains something that looks like a canary,
+	// an empty token must never report found.
+	result := s.CheckCanary("response containing <!--CANARY-abc123-->", "")
+	if result.Found {
+		t.Fatal("empty token must never produce Found=true")
+	}
+}
+
+func TestCheckCanary_PartialMatchShouldFail(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	_, token, err := s.InjectCanary("some prompt")
+	if err != nil {
+		t.Fatalf("InjectCanary error: %v", err)
+	}
+
+	partial := strings.TrimSuffix(strings.TrimPrefix(token, canaryPrefix), canarySuffix)
+	response := "response containing only partial token: " + partial
+	result := s.CheckCanary(response, token)
+	if result.Found {
+		t.Fatalf("expected partial token match to fail, token=%q partial=%q", token, partial)
+	}
+}

--- a/shield_test.go
+++ b/shield_test.go
@@ -190,22 +190,38 @@ func TestInjectCanaryAddsToken(t *testing.T) {
 	}
 }
 
-func TestInjectCanaryTokenIsUnique(t *testing.T) {
+func TestInjectCanaryTokenFormat(t *testing.T) {
 	s, err := New(Config{})
 	if err != nil {
 		t.Fatalf("New returned unexpected error: %v", err)
 	}
 
-	_, token1, err := s.InjectCanary("prompt")
+	_, token, err := s.InjectCanary("prompt")
 	if err != nil {
-		t.Fatalf("first InjectCanary error: %v", err)
+		t.Fatalf("InjectCanary error: %v", err)
 	}
-	_, token2, err := s.InjectCanary("prompt")
-	if err != nil {
-		t.Fatalf("second InjectCanary error: %v", err)
+
+	// Verify token structure: <!--CANARY-<16 hex chars>-->
+	if !strings.HasPrefix(token, canaryPrefix) {
+		t.Fatalf("token missing expected prefix %q: got %q", canaryPrefix, token)
 	}
-	if token1 == token2 {
-		t.Fatalf("expected unique tokens across calls, both were %q", token1)
+	if !strings.HasSuffix(token, canarySuffix) {
+		t.Fatalf("token missing expected suffix %q: got %q", canarySuffix, token)
+	}
+
+	// Extract hex portion and verify length (8 bytes = 16 hex chars)
+	hexPart := strings.TrimSuffix(strings.TrimPrefix(token, canaryPrefix), canarySuffix)
+	if len(hexPart) != 16 {
+		t.Fatalf("expected 16 hex characters, got %d: %q", len(hexPart), hexPart)
+	}
+
+	// Verify it's valid lowercase hex
+	for _, c := range hexPart {
+		isDigit := c >= '0' && c <= '9'
+		isLowerHex := c >= 'a' && c <= 'f'
+		if !isDigit && !isLowerHex {
+			t.Fatalf("token contains non-hex character %q in %q", c, hexPart)
+		}
 	}
 }
 
@@ -278,5 +294,129 @@ func TestCheckCanary_PartialMatchShouldFail(t *testing.T) {
 	result := s.CheckCanary(response, token)
 	if result.Found {
 		t.Fatalf("expected partial token match to fail, token=%q partial=%q", token, partial)
+	}
+}
+
+func TestInjectCanary_EmptyPrompt(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	// Empty prompt should still work - canary is appended with newline
+	augmented, token, err := s.InjectCanary("")
+	if err != nil {
+		t.Fatalf("InjectCanary error: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty token even for empty prompt")
+	}
+	// Result should be "\n" + token
+	expected := "\n" + token
+	if augmented != expected {
+		t.Fatalf("expected %q, got %q", expected, augmented)
+	}
+}
+
+func TestInjectCanary_WhitespacePrompt(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	// Whitespace-only prompt should preserve the whitespace
+	augmented, token, err := s.InjectCanary("   ")
+	if err != nil {
+		t.Fatalf("InjectCanary error: %v", err)
+	}
+	expected := "   \n" + token
+	if augmented != expected {
+		t.Fatalf("expected %q, got %q", expected, augmented)
+	}
+}
+
+func TestCheckCanary_ResponseWithFormatting(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	_, token, err := s.InjectCanary("prompt")
+	if err != nil {
+		t.Fatalf("InjectCanary error: %v", err)
+	}
+
+	// Test various realistic LLM response formats where canary might appear
+	cases := []struct {
+		name     string
+		response string
+		want     bool
+	}{
+		{"in markdown code fence", "```\n" + token + "\n```", true},
+		{"surrounded by quotes", `The hidden text was "` + token + `"`, true},
+		{"with extra whitespace", "  " + token + "  ", true},
+		{"in bullet list", "- Item 1\n- " + token + "\n- Item 3", true},
+		{"with punctuation after", token + "!!!", true},
+		{"token broken across lines", strings.Replace(token, "-", "-\n", 1), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := s.CheckCanary(tc.response, token)
+			if result.Found != tc.want {
+				t.Errorf("CheckCanary(%q) = Found:%v, want:%v", tc.name, result.Found, tc.want)
+			}
+		})
+	}
+}
+
+// TestCheckCanary_TokenStrippedByPipeline documents the limitation that
+// canary detection only works if the token survives the transport pipeline.
+// If HTML comments are stripped (by sanitizers, markdown processors, etc.),
+// the canary will not be detected, and that's expected behavior.
+func TestCheckCanary_TokenStrippedByPipeline(t *testing.T) {
+	s, err := New(Config{})
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	_, token, err := s.InjectCanary("Summarize this document.")
+	if err != nil {
+		t.Fatalf("InjectCanary error: %v", err)
+	}
+
+	// Simulate a pipeline that strips HTML comments before reaching the LLM
+	// or before returning the response to us.
+	stripHTMLComments := func(s string) string {
+		// Naive strip: remove anything matching <!--...-->
+		result := s
+		for {
+			start := strings.Index(result, "<!--")
+			if start == -1 {
+				break
+			}
+			end := strings.Index(result[start:], "-->")
+			if end == -1 {
+				break
+			}
+			result = result[:start] + result[start+end+3:]
+		}
+		return result
+	}
+
+	// The token was in the response, but got stripped
+	originalResponse := "Here is your summary. " + token + " Hope this helps!"
+	strippedResponse := stripHTMLComments(originalResponse)
+
+	// After stripping, the canary should NOT be found
+	// This is expected behavior, not a bug - the limitation is documented
+	result := s.CheckCanary(strippedResponse, token)
+	if result.Found {
+		t.Fatal("canary should not be found after HTML comment stripping")
+	}
+
+	// Verify the stripping actually removed the token
+	if strings.Contains(strippedResponse, token) {
+		t.Fatal("test setup error: token was not actually stripped")
 	}
 }


### PR DESCRIPTION
## Summary

Adds a canary token system for prompt leakage detection via `InjectCanary` and `CheckCanary`.

Closes #28.

Supersedes #35, which can be closed.